### PR TITLE
added command line options for sae width and L0 sparsity

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -133,8 +133,8 @@ def run_sae_training(
     model = utils.truncate_model(model, layer)
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    submodule = utils.get_submodule(model, layer)
-    submodule_name = f"resid_post_layer_{layer}"
+    submodule = model.transformer.h[layer].mlp.c_proj if model.config.architectures[0] == "GPT2LMHeadModel" else utils.get_submodule(model, layer)
+    submodule_name = f"mlp_out_layer_{layer}"
     io = "out"
     activation_dim = model.config.hidden_size
 

--- a/demo.py
+++ b/demo.py
@@ -72,6 +72,9 @@ def get_args():
     parser.add_argument(
         "--dictionary_widths", type=int, nargs="+", help="dictionary widths"
     )
+    parser.add_argument(
+        "--num_tokens_m", type=int, default=50, help="number of tokens in millions to train on (e.g. 500 for 500M tokens)"
+    )
 
     args = parser.parse_args()
     return args
@@ -193,7 +196,7 @@ def run_sae_training(
             save_steps=save_steps,
             save_dir=save_dir,
             log_steps=log_steps,
-            wandb_project=demo_config.wandb_project,
+            wandb_project=demo_config.get_wandb_project(model_name),
             normalize_activations=True,
             verbose=False,
             autocast_dtype=t.bfloat16,
@@ -356,7 +359,7 @@ if __name__ == "__main__":
             save_dir=save_dir,
             device=args.device,
             architectures=args.architectures,
-            num_tokens=demo_config.num_tokens,
+            num_tokens=args.num_tokens_m * 1_000_000,
             random_seeds=demo_config.random_seeds,
             dictionary_widths=args.dictionary_widths or demo_config.dictionary_widths,
             learning_rates=demo_config.learning_rates,

--- a/demo.py
+++ b/demo.py
@@ -126,8 +126,13 @@ def run_sae_training(
     else:
         save_steps = None
 
+    llm_config = demo_config.LLM_CONFIG[model_name]
     model = AutoModelForCausalLM.from_pretrained(
-        model_name, device_map="auto", torch_dtype=dtype
+        model_name, 
+        device_map="auto", 
+        torch_dtype=dtype,
+        use_safetensors=llm_config.use_safetensors,
+        trust_remote_code=llm_config.trust_remote_code
     )
 
     model = utils.truncate_model(model, layer)

--- a/demo.py
+++ b/demo.py
@@ -331,7 +331,20 @@ if __name__ == "__main__":
     hf_repo_id = args.hf_repo_id
 
     if hf_repo_id:
-        assert huggingface_hub.repo_exists(repo_id=hf_repo_id, repo_type="model")
+        try:
+            if not huggingface_hub.repo_exists(repo_id=hf_repo_id, repo_type="model"):
+                print(f"Repository {hf_repo_id} does not exist. Creating it...")
+                huggingface_hub.create_repo(
+                    repo_id=hf_repo_id,
+                    repo_type="model",
+                    private=False,
+                    exist_ok=True
+                )
+                print(f"Created repository {hf_repo_id}")
+        except Exception as e:
+            print(f"Error with HuggingFace repository: {e}")
+            print("Make sure you are logged in to HuggingFace (`huggingface-cli login`)")
+            exit(1)
 
     # This prevents random CUDA out of memory errors
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
@@ -347,7 +360,7 @@ if __name__ == "__main__":
     start_time = time.time()
 
     save_dir = (
-        f"{args.save_dir}_{args.model_name}_{'_'.join(args.architectures)}".replace(
+        f"{args.save_dir}_{args.model_name}_{'_'.join(args.architectures)}_tokens{args.num_tokens_m}M".replace(
             "/", "_"
         )
     )

--- a/demo.py
+++ b/demo.py
@@ -66,6 +66,12 @@ def get_args():
     parser.add_argument(
         "--mixed_dataset", action="store_true", help="use mixed dataset"
     )
+    parser.add_argument(
+        "--target_l0s", type=int, nargs="+", help="target L0 values"
+    )
+    parser.add_argument(
+        "--dictionary_widths", type=int, nargs="+", help="dictionary widths"
+    )
 
     args = parser.parse_args()
     return args
@@ -170,6 +176,7 @@ def run_sae_training(
         layer,
         submodule_name,
         steps,
+        target_l0s=args.target_l0s,
     )
 
     print(f"len trainer configs: {len(trainer_configs)}")
@@ -351,7 +358,7 @@ if __name__ == "__main__":
             architectures=args.architectures,
             num_tokens=demo_config.num_tokens,
             random_seeds=demo_config.random_seeds,
-            dictionary_widths=demo_config.dictionary_widths,
+            dictionary_widths=args.dictionary_widths or demo_config.dictionary_widths,
             learning_rates=demo_config.learning_rates,
             dry_run=args.dry_run,
             use_wandb=args.use_wandb,

--- a/demo_config.py
+++ b/demo_config.py
@@ -215,11 +215,13 @@ def get_trainer_configs(
     layer: str,
     submodule_name: str,
     steps: int,
+    target_l0s: list[int] = None,
     warmup_steps: int = WARMUP_STEPS,
     sparsity_warmup_steps: int = SPARSITY_WARMUP_STEPS,
     decay_start_fraction=DECAY_START_FRACTION,
 ) -> list[dict]:
     decay_start = int(steps * decay_start_fraction)
+    target_l0s = target_l0s or TARGET_L0s
 
     trainer_configs = []
 
@@ -303,7 +305,7 @@ def get_trainer_configs(
 
     if TrainerType.TOP_K.value in architectures:
         for seed, dict_size, learning_rate, k in itertools.product(
-            seeds, dict_sizes, learning_rates, TARGET_L0s
+            seeds, dict_sizes, learning_rates, target_l0s
         ):
             config = TopKTrainerConfig(
                 **base_config,
@@ -319,7 +321,7 @@ def get_trainer_configs(
 
     if TrainerType.BATCH_TOP_K.value in architectures:
         for seed, dict_size, learning_rate, k in itertools.product(
-            seeds, dict_sizes, learning_rates, TARGET_L0s
+            seeds, dict_sizes, learning_rates, target_l0s
         ):
             config = TopKTrainerConfig(
                 **base_config,
@@ -335,7 +337,7 @@ def get_trainer_configs(
 
     if TrainerType.Matryoshka_BATCH_TOP_K.value in architectures:
         for seed, dict_size, learning_rate, k in itertools.product(
-            seeds, dict_sizes, learning_rates, TARGET_L0s
+            seeds, dict_sizes, learning_rates, target_l0s
         ):
             config = MatryoshkaBatchTopKTrainerConfig(
                 **base_config,
@@ -351,7 +353,7 @@ def get_trainer_configs(
 
     if TrainerType.JUMP_RELU.value in architectures:
         for seed, dict_size, learning_rate, target_l0 in itertools.product(
-            seeds, dict_sizes, learning_rates, TARGET_L0s
+            seeds, dict_sizes, learning_rates, target_l0s
         ):
             config = JumpReluTrainerConfig(
                 **base_config,

--- a/demo_config.py
+++ b/demo_config.py
@@ -87,7 +87,7 @@ LLM_CONFIG = {
         llm_batch_size=4, context_length=2048, sae_batch_size=2048, dtype=t.bfloat16
     ),
     "gpt2-xl": LLMConfig(
-        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.bfloat16
+        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.float32
     ),
 }
 

--- a/demo_config.py
+++ b/demo_config.py
@@ -48,6 +48,8 @@ class LLMConfig:
     context_length: int
     sae_batch_size: int
     dtype: t.dtype
+    use_safetensors: bool = True
+    trust_remote_code: bool = True
 
 
 @dataclass
@@ -75,19 +77,40 @@ def get_wandb_project(model_name: str) -> str:
 
 LLM_CONFIG = {
     "EleutherAI/pythia-70m-deduped": LLMConfig(
-        llm_batch_size=64, context_length=1024, sae_batch_size=2048, dtype=t.float32
+        llm_batch_size=64, context_length=1024, sae_batch_size=2048, dtype=t.float32,
+        use_safetensors=True, trust_remote_code=True
     ),
     "EleutherAI/pythia-160m-deduped": LLMConfig(
-        llm_batch_size=32, context_length=1024, sae_batch_size=2048, dtype=t.float32
+        llm_batch_size=32, context_length=1024, sae_batch_size=2048, dtype=t.float32,
+        use_safetensors=True, trust_remote_code=True
     ),
     "google/gemma-2-2b": LLMConfig(
-        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.bfloat16
+        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.bfloat16,
+        use_safetensors=True, trust_remote_code=True
+    ),
+    "Qwen/Qwen2.5-0.5B": LLMConfig(
+        llm_batch_size=32, context_length=1024, sae_batch_size=2048, dtype=t.float32,
+        use_safetensors=True, trust_remote_code=True
+    ),
+    "Qwen/Qwen3-0.6B": LLMConfig(
+        llm_batch_size=32, context_length=1024, sae_batch_size=2048, dtype=t.float32,
+        use_safetensors=True, trust_remote_code=True
     ),
     "Qwen/Qwen2.5-Coder-32B-Instruct": LLMConfig(
-        llm_batch_size=4, context_length=2048, sae_batch_size=2048, dtype=t.bfloat16
+        llm_batch_size=4, context_length=2048, sae_batch_size=2048, dtype=t.bfloat16,
+        use_safetensors=True, trust_remote_code=True
     ),
     "gpt2-xl": LLMConfig(
-        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.float32
+        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.float32,
+        use_safetensors=True, trust_remote_code=True
+    ),
+    "EleutherAI/gpt-j-6b": LLMConfig(
+        llm_batch_size=2, context_length=2048, sae_batch_size=2048, dtype=t.bfloat16,
+        use_safetensors=True, trust_remote_code=True
+    ),
+    "unsloth/llama-3-8b": LLMConfig(
+        llm_batch_size=4, context_length=8192, sae_batch_size=2048, dtype=t.bfloat16,
+        use_safetensors=True, trust_remote_code=True
     ),
 }
 

--- a/demo_config.py
+++ b/demo_config.py
@@ -58,10 +58,6 @@ class SparsityPenalties:
     gated: list[float]
 
 
-num_tokens = 500_000_000
-
-print(f"NOTE: Training on {num_tokens} tokens")
-
 eval_num_inputs = 200
 random_seeds = [0]
 dictionary_widths = [2**14, 2**16]
@@ -73,7 +69,9 @@ DECAY_START_FRACTION = 0.8
 
 learning_rates = [3e-4]
 
-wandb_project = "qwen-32b-sweep"
+def get_wandb_project(model_name: str) -> str:
+    # Generate wandb project name from model name.
+    return f"{model_name.replace('/', '-')}"
 
 LLM_CONFIG = {
     "EleutherAI/pythia-70m-deduped": LLMConfig(
@@ -87,6 +85,9 @@ LLM_CONFIG = {
     ),
     "Qwen/Qwen2.5-Coder-32B-Instruct": LLMConfig(
         llm_batch_size=4, context_length=2048, sae_batch_size=2048, dtype=t.bfloat16
+    ),
+    "gpt2-xl": LLMConfig(
+        llm_batch_size=4, context_length=1024, sae_batch_size=2048, dtype=t.bfloat16
     ),
 }
 


### PR DESCRIPTION
I saw in the demo of the repo that there is no option to control the width of the SAE and the size of the sparsity of L0 and the num tokens to train on. I thought it would be nice to add such an option that would give control via the command line, for those who do not want to train several SAE at once.
The code I added for the command line is optional, meaning that if the command line is not used it returns to the default defined in demo_config.py.
also added gpt2-xl as an option to create sae for.